### PR TITLE
Shrink release AAB: drop x86 ABIs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -62,12 +62,8 @@ android {
                 signingConfigs.getByName("debug")
             else
                 signingConfigs.getByName("release")
-            isMinifyEnabled = true
-            isShrinkResources = true
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
+            isMinifyEnabled = false
+            isShrinkResources = false
         }
     }
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -33,6 +33,16 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        ndk {
+            abiFilters += listOf("armeabi-v7a", "arm64-v8a")
+        }
+    }
+
+    packaging {
+        jniLibs {
+            excludes += setOf("lib/x86/**", "lib/x86_64/**")
+        }
     }
 
     signingConfigs {
@@ -52,6 +62,12 @@ android {
                 signingConfigs.getByName("debug")
             else
                 signingConfigs.getByName("release")
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,3 +1,0 @@
-# Project-specific ProGuard / R8 rules.
-# Plugins ship their own consumer rules via AAR, so this file is intentionally
-# empty by default. Add app-specific keep rules here as needed.

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Project-specific ProGuard / R8 rules.
+# Plugins ship their own consumer rules via AAR, so this file is intentionally
+# empty by default. Add app-specific keep rules here as needed.


### PR DESCRIPTION
## Summary
- Drops x86 / x86_64 native libs from the release AAB via `packaging.jniLibs.excludes` (Android phones are ARM; x86 is emulator-only)
- Explicitly disables R8 (`isMinifyEnabled = false`, `isShrinkResources = false`) — see note below

Release AAB drops from **~51 MB → ~33 MB** (≈35% smaller upload). End-user download size is even smaller after Play's per-device split.

## Why R8 is off
Flutter (or one of the Gradle plugins, likely `com.google.firebase.crashlytics`) enables R8 for release builds by default. Combined with `firebase-bom:33.7.0`, R8 strips the constructors of the Kotlin `-ktx` `ComponentRegistrar` classes (`FirebaseInstallationsKtxRegistrar`, `CrashlyticsNdkRegistrar`, `CrashlyticsRegistrar`), which makes `Firebase.initializeApp` throw `NoSuchMethodException` at runtime and crashes the app immediately on launch.

This was verified by physical install on a Samsung Galaxy S22 (`SM S908E`, Android 16):
- With R8 → `[core/no-app] No Firebase App '[DEFAULT]' has been created` and stuck on logo
- With R8 off → `FirebaseApp initialization successful`, `Initializing Firebase Crashlytics 19.4.4`, app works normally

Adding Firebase keep rules is a follow-up. For now we take the ABI-only win.

## Test plan
- [x] `flutter build appbundle --release` succeeds
- [x] Output AAB contains only `armeabi-v7a` and `arm64-v8a` (verified via `unzip -l`)
- [x] Signing cert matches the upload cert (SHA1 `87:30:54:62:B2:3B:4E:B4:22:0B:D3:1F:49:51:0C:C3:AB:AD:11:03`)
- [x] Installed on Samsung Galaxy S22; Firebase initializes, app reaches home screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)