### PR TITLE
Add Firebase Analytics events for playback

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,8 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:path_provider/path_provider.dart';
 
 import 'firebase_options.dart';
+import 'src/analytics/analytics_logger.dart';
+import 'src/analytics/firebase_analytics_logger.dart';
 import 'src/home_screen.dart';
 import 'src/l10n/strings.dart';
 import 'src/playback/audio_handler.dart';
@@ -45,10 +47,13 @@ Future<void> main() async {
 }
 
 Future<void> _bootstrap() async {
+  final AnalyticsLogger analytics =
+      kIsWeb ? const NoOpAnalyticsLogger() : FirebaseAnalyticsLogger();
   final controller = PlaybackController(
     player: JustAudioRadioPlayer(),
     preference: SharedPreferencesBitratePreference(),
     stationFallback: kStrings['station_name']!,
+    analytics: analytics,
   );
   await controller.load();
 

--- a/lib/src/analytics/analytics_logger.dart
+++ b/lib/src/analytics/analytics_logger.dart
@@ -1,0 +1,16 @@
+/// Engine-agnostic analytics sink used by [PlaybackController].
+///
+/// Decouples the playback state machine from `firebase_analytics` so the
+/// controller stays unit-testable without a Firebase platform channel.
+library;
+
+abstract class AnalyticsLogger {
+  Future<void> logEvent(String name, Map<String, Object?> params);
+}
+
+class NoOpAnalyticsLogger implements AnalyticsLogger {
+  const NoOpAnalyticsLogger();
+
+  @override
+  Future<void> logEvent(String name, Map<String, Object?> params) async {}
+}

--- a/lib/src/analytics/firebase_analytics_logger.dart
+++ b/lib/src/analytics/firebase_analytics_logger.dart
@@ -1,0 +1,26 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+import 'analytics_logger.dart';
+
+class FirebaseAnalyticsLogger implements AnalyticsLogger {
+  final FirebaseAnalytics _analytics;
+  FirebaseAnalyticsLogger([FirebaseAnalytics? analytics])
+      : _analytics = analytics ?? FirebaseAnalytics.instance;
+
+  @override
+  Future<void> logEvent(String name, Map<String, Object?> params) {
+    final sanitized = <String, Object>{};
+    params.forEach((key, value) {
+      if (value == null) return;
+      if (value is String) {
+        sanitized[key] = value.length > 100 ? value.substring(0, 100) : value;
+      } else if (value is num || value is bool) {
+        sanitized[key] = value;
+      } else {
+        final s = value.toString();
+        sanitized[key] = s.length > 100 ? s.substring(0, 100) : s;
+      }
+    });
+    return _analytics.logEvent(name: name, parameters: sanitized);
+  }
+}

--- a/lib/src/playback/playback_controller.dart
+++ b/lib/src/playback/playback_controller.dart
@@ -13,6 +13,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../analytics/analytics_logger.dart';
 import 'endpoint_catalog.dart';
 import 'bitrate_preference.dart';
 import 'icy_metadata.dart';
@@ -66,6 +67,7 @@ class PlaybackController {
   final BitratePreference _preference;
   final ReconnectPolicy _policy;
   final String _stationFallback;
+  final AnalyticsLogger _analytics;
 
   final ValueNotifier<PlaybackState> _state =
       ValueNotifier<PlaybackState>(kInitialState);
@@ -90,10 +92,12 @@ class PlaybackController {
     required BitratePreference preference,
     ReconnectPolicy policy = const ReconnectPolicy(),
     String stationFallback = 'DUBSTEP.FM',
+    AnalyticsLogger analytics = const NoOpAnalyticsLogger(),
   })  : _player = player,
         _preference = preference,
         _policy = policy,
-        _stationFallback = stationFallback {
+        _stationFallback = stationFallback,
+        _analytics = analytics {
     _eventSub = _player.events.listen(_onEngineEvent);
     _icySub = _player.icyMetadata.listen(_onIcyFrame);
   }
@@ -121,6 +125,10 @@ class PlaybackController {
     _cancelRetryTimer();
     _state.value = const LoadingState();
     _armSlowLoadTimer();
+    unawaited(_analytics.logEvent('playback_start', {
+      'bitrate_kbps': endpointForUrl(_currentUrl).bitrateKbps,
+      'url': _currentUrl,
+    }));
     await _player.setUrlAndPlay(_currentUrl);
   }
 
@@ -149,6 +157,10 @@ class PlaybackController {
       _cancelRetryTimer();
       _state.value = const LoadingState();
       _armSlowLoadTimer();
+      unawaited(_analytics.logEvent('playback_start', {
+        'bitrate_kbps': endpointForUrl(url).bitrateKbps,
+        'url': url,
+      }));
       await _player.setUrlAndPlay(url);
     }
     // In Idle / Error: persist but do not auto-start.
@@ -202,12 +214,26 @@ class PlaybackController {
         if (s is LoadingState || s is PlayingState) {
           _buffering.value = false;
           _retryCount += 1;
-          if (_retryCount >= _policy.maxAttempts) {
+          final willRetry = _retryCount < _policy.maxAttempts;
+          unawaited(_analytics.logEvent('playback_error', {
+            'bitrate_kbps': endpointForUrl(_currentUrl).bitrateKbps,
+            'url': _currentUrl,
+            'reason': _describeCause(cause),
+            'phase': s is LoadingState ? 'loading' : 'playing',
+            'retry_count': _retryCount,
+            'will_retry': willRetry,
+          }));
+          if (!willRetry) {
             _retryCount = 0;
             _cancelRetryTimer();
             _cancelSlowLoadTimer();
             _state.value = ErrorState(cause);
             _pushClearedItem();
+            unawaited(_analytics.logEvent('playback_failed', {
+              'bitrate_kbps': endpointForUrl(_currentUrl).bitrateKbps,
+              'url': _currentUrl,
+              'reason': _describeCause(cause),
+            }));
             // Best-effort: ensure the engine is in a stopped state too.
             unawaited(_player.stop());
           } else {
@@ -311,6 +337,11 @@ class PlaybackController {
       url: _currentUrl,
       clearedToFallback: true,
     );
+  }
+
+  String _describeCause(Object cause) {
+    final s = cause.toString();
+    return s.length > 100 ? s.substring(0, 100) : s;
   }
 
   void _ensureNotDisposed() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,6 +161,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  firebase_analytics:
+    dependency: "direct main"
+    description:
+      name: firebase_analytics
+      sha256: "4f85b161772e1d54a66893ef131c0a44bd9e552efa78b33d5f4f60d2caa5c8a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.6.0"
+  firebase_analytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_analytics_platform_interface
+      sha256: a44b6d1155ed5cae7641e3de7163111cfd9f6f6c954ca916dc6a3bdfa86bf845
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.3"
+  firebase_analytics_web:
+    dependency: transitive
+    description:
+      name: firebase_analytics_web
+      sha256: c7d1ed1f86ae64215757518af5576ff88341c8ce5741988c05cc3b2e07b0b273
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.10+16"
   firebase_core:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.0+20001
+version: 2.0.3+20003
 
 environment:
   sdk: ^3.12.1
@@ -38,6 +38,7 @@ dependencies:
   # Firebase Crashlytics for crash + non-fatal error reporting.
   firebase_core: ^3.6.0
   firebase_crashlytics: ^4.1.3
+  firebase_analytics: ^11.3.3
 
   # Live MP3 streaming + ICY metadata (R1).
   just_audio: ^0.10.0


### PR DESCRIPTION
## Summary
Wire Firebase Analytics events into the playback state machine so we can answer two questions in the console:
1. How often listeners start playback, broken down by chosen bitrate.
2. How often the stream fails, separating transient errors (we retry) from terminal "Can't connect" screens.

Three events:
| Event | When | Params |
|---|---|---|
| \`playback_start\` | User taps PLAY or switches bitrate while playing | \`bitrate_kbps\`, \`url\` |
| \`playback_error\` | Every engine error (loading or mid-play) | \`bitrate_kbps\`, \`url\`, \`reason\`, \`phase\` (\`loading\`/\`playing\`), \`retry_count\`, \`will_retry\` |
| \`playback_failed\` | Controller exhausted retries — "Can't connect" screen | \`bitrate_kbps\`, \`url\`, \`reason\` |

\`reason\` is the engine cause stringified and capped at 100 chars (Firebase param limit).

## Design notes
- New \`AnalyticsLogger\` interface in \`lib/src/analytics/\` keeps \`PlaybackController\` unit-testable — production wires \`FirebaseAnalyticsLogger\`, tests use the default \`NoOpAnalyticsLogger\`.
- Rides on existing \`firebase_core\` setup; no new \`google-services.json\` / \`GoogleService-Info.plist\` changes required.
- Bumps build to \`2.0.3+20003\` for the next TestFlight upload.

## Test plan
- [x] \`flutter analyze\` clean.
- [x] \`flutter test\` — all 44 tests pass.
- [ ] Verify events arrive in Firebase DebugView on iOS (launch arg \`-FIRDebugEnabled\`) and Android (\`adb shell setprop debug.firebase.analytics.app fm.dubstep.audio\`).
- [ ] Confirm \`playback_failed\` fires exactly once per "Can't connect" screen (not per engine error during the retry chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)