### PR TITLE
Fix three Android crashes; bump to 2.0.4

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,6 +41,13 @@ android {
 
     packaging {
         jniLibs {
+            // Extract native libs (libflutter.so, libapp.so, …) onto the
+            // filesystem at install time instead of leaving them compressed in
+            // the APK. AGP defaults this to false (extractNativeLibs="false"),
+            // but ReLinker — used by the Flutter loader — throws
+            // MissingLibraryException ("only found: []") on some devices and
+            // sideload / split-install paths when the libs stay in-APK.
+            useLegacyPackaging = true
             excludes += setOf("lib/x86/**", "lib/x86_64/**")
         }
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,7 @@ Future<void> main() async {
       FlutterError.onError =
           FirebaseCrashlytics.instance.recordFlutterFatalError;
       PlatformDispatcher.instance.onError = (error, stack) {
-        FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+        _recordError(error, stack);
         return true;
       };
     }
@@ -41,9 +41,35 @@ Future<void> main() async {
     await _bootstrap();
   }, (error, stack) {
     if (!kIsWeb) {
-      FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+      _recordError(error, stack);
     }
   });
+}
+
+/// Record an uncaught zone/platform error to Crashlytics, downgrading
+/// transient network failures to non-fatal.
+///
+/// just_audio runs a local proxy HTTP server for the stream; when the device
+/// has no connectivity it throws `SocketException: Connection failed (Network
+/// is unreachable)` from inside that proxy, on an async path the player's
+/// `errorStream` never sees. It surfaces here as an uncaught error. The
+/// reconnect policy already handles the user-facing recovery, so flagging it
+/// `fatal: true` only pollutes crash-free-users with what is really a
+/// "no internet" condition. Report it as a non-fatal instead.
+void _recordError(Object error, StackTrace stack) {
+  FirebaseCrashlytics.instance
+      .recordError(error, stack, fatal: !_isTransientNetworkError(error));
+}
+
+bool _isTransientNetworkError(Object error) {
+  if (error is SocketException || error is HttpException) return true;
+  final message = error.toString();
+  return message.contains('SocketException') ||
+      message.contains('Network is unreachable') ||
+      message.contains('Connection failed') ||
+      message.contains('Connection refused') ||
+      message.contains('Connection reset') ||
+      message.contains('Connection closed');
 }
 
 Future<void> _bootstrap() async {
@@ -64,17 +90,27 @@ Future<void> _bootstrap() async {
     // which only understands http(s)/file/content URIs — not asset://. Stage
     // the bundled logo into the cache dir and hand back a file:// URI.
     final artUri = await _stageNotificationArt();
-    await AudioService.init(
-      builder: () => DubstepAudioHandler(controller, artUri: artUri),
-      config: AudioServiceConfig(
-        androidNotificationChannelId: 'fm.dubstep.audio',
-        androidNotificationChannelName:
-            kStrings['notification_channel_name']!,
-        androidNotificationOngoing: true,
-        androidStopForegroundOnPause: true,
-        androidNotificationIcon: 'mipmap/ic_launcher',
-      ),
-    );
+    // audio_service's Android configure() reads the launching Activity's
+    // intent; on some devices/launch paths that intent is null and it throws
+    // `PlatformException(... Intent.mAction on a null object reference ...)`,
+    // which otherwise aborts the whole launch. Degrade gracefully: without the
+    // media session we lose the system notification / lock-screen controls,
+    // but in-app PLAY/STOP still works. Report the failure as non-fatal.
+    try {
+      await AudioService.init(
+        builder: () => DubstepAudioHandler(controller, artUri: artUri),
+        config: AudioServiceConfig(
+          androidNotificationChannelId: 'fm.dubstep.audio',
+          androidNotificationChannelName:
+              kStrings['notification_channel_name']!,
+          androidNotificationOngoing: true,
+          androidStopForegroundOnPause: true,
+          androidNotificationIcon: 'mipmap/ic_launcher',
+        ),
+      );
+    } catch (error, stack) {
+      FirebaseCrashlytics.instance.recordError(error, stack, fatal: false);
+    }
 
     final session = await AudioSession.instance;
     await session.configure(const AudioSessionConfiguration.music());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.3+20003
+version: 2.0.4+20004
 
 environment:
   sdk: ^3.12.1


### PR DESCRIPTION
## Summary

Fixes the three top Android crashes reported in Crashlytics, in one release (`2.0.3+20003` → `2.0.4+20004`).

### 1. `MissingLibraryException: Could not find 'libflutter.so'` (`only found: []`)
ReLinker (used by the Flutter loader) can't locate the native libs on some devices and split/sideload install paths when they stay compressed inside the APK. Set `jniLibs.useLegacyPackaging = true` so the libs are extracted to the filesystem at install time.

### 2. `SocketException: Connection failed (Network is unreachable)` reported as fatal
just_audio runs a local proxy HTTP server for the stream; with no connectivity it throws this from inside the proxy on an async path the player's `errorStream` never sees, so it surfaces as an uncaught **fatal** error. The reconnect policy already handles the user-facing recovery — this is really a "no internet" condition. Route uncaught errors through a helper that records transient network failures as **non-fatal**.

### 3. `PlatformException(... Intent.mAction on a null object reference ...)` during `AudioService.init`
On some launch paths the Activity intent is null and audio_service's `configure()` throws, aborting the whole launch. Guard `AudioService.init` in try/catch so the app still launches (without the media session / lock-screen controls) and report the failure as non-fatal.

## Test
- `flutter analyze` — no issues
- `flutter test` — all 44 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)