### PR TITLE
Fix audio focus: let just_audio own audio-session activation

### DIFF
--- a/lib/src/playback/just_audio_radio_player.dart
+++ b/lib/src/playback/just_audio_radio_player.dart
@@ -33,10 +33,20 @@ class JustAudioRadioPlayer implements RadioPlayer {
       : _player = player ??
             ja.AudioPlayer(
               userAgent: _userAgent,
-              // audio_session / audio_service own focus and noisy handling.
+              // We own interruption *reactions* (audio_session's
+              // interruptionEventStream / becomingNoisyEventStream call
+              // controller.stop()), so just_audio must not also pause/resume.
               handleInterruptions: false,
-              // audio_service activates the session; just_audio should not.
-              handleAudioSessionActivation: false,
+              // …but just_audio MUST own audio-session activation. It calls
+              // session.setActive(true) before each play (requesting audio
+              // focus) and deactivates on stop. Without this nothing ever
+              // requests focus, so (a) interruptionEventStream never fires —
+              // calls don't pause the radio — and (b) on iOS, after a route
+              // change leaves the AVAudioSession inactive, playback stalls
+              // "connecting" forever until app restart. Reactivating on every
+              // play fixes both. (audio_service does NOT request focus itself
+              // when paired with just_audio — verified empirically.)
+              handleAudioSessionActivation: true,
             ) {
     _stateSub = _player.playerStateStream.listen(_onPlayerState);
     _errorSub = _player.errorStream.listen(_onError);


### PR DESCRIPTION
## Problem

The `AudioPlayer` was built with `handleAudioSessionActivation: false`, on the assumption (per the old comment) that `audio_service` activates the audio session. It doesn't — verified on device that **nothing ever calls `requestAudioFocus`**, so the app never held audio focus. Two bugs followed:

1. **Calls don't pause the radio.** `audio_session`'s `interruptionEventStream` only fires when the app holds focus, so the `controller.stop()` handler in `main.dart` was effectively dead code. During a phone call the OS just ducked our stream while the player kept running.
2. **iOS "connecting forever."** After a route change (e.g. AirPods → laptop) leaves the `AVAudioSession` inactive, hitting PLAY stalls on an inactive session indefinitely; switching bitrate reuses the same wedged session, so only an app restart recovers.

## Fix

Flip `handleAudioSessionActivation` to `true` (keep `handleInterruptions: false`). `just_audio` now calls `session.setActive(true)` before each play (acquiring focus) and deactivates on stop, while our `audio_session` handlers keep owning the *reactions*. Reactivating on every play is exactly what the iOS recovery needs.

## Verification (Android emulator, API 35)

- ✅ App now requests focus: `requestAudioFocus … USAGE_MEDIA … GAIN`
- ✅ Incoming call → `onAudioFocusChange(-2)` delivered → playback pauses to **Idle** (previously kept playing)
- ✅ PLAY after the call resumes `CONNECTING → PLAYING` in ~1.3s — **no hang**
- ✅ Bad-internet reconnect path unaffected; no crash
- ✅ `flutter analyze` clean, **44 tests pass**

**Note:** the iOS "connecting forever" fix is inferred from the shared root cause and validated on Android (which doesn't reproduce that specific hang, since ExoPlayer doesn't gate on the session). Worth confirming the AirPods→laptop→PLAY round-trip on a real iOS device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)