### PR TITLE
Fix Firebase Analytics bool crash; bump to 2.0.7

### DIFF
--- a/lib/src/analytics/firebase_analytics_logger.dart
+++ b/lib/src/analytics/firebase_analytics_logger.dart
@@ -14,7 +14,11 @@ class FirebaseAnalyticsLogger implements AnalyticsLogger {
       if (value == null) return;
       if (value is String) {
         sanitized[key] = value.length > 100 ? value.substring(0, 100) : value;
-      } else if (value is num || value is bool) {
+      } else if (value is bool) {
+        // Firebase Analytics only accepts String or num parameter values;
+        // a raw bool trips an assertion. Encode as 1/0.
+        sanitized[key] = value ? 1 : 0;
+      } else if (value is num) {
         sanitized[key] = value;
       } else {
         final s = value.toString();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.6+20006
+version: 2.0.7+20007
 
 environment:
   sdk: ^3.12.1


### PR DESCRIPTION
## Summary
Fixes the Crashlytics fatal seen on 2.0.5/2.0.6:

> `Failed assertion: 'value is String || value is num': 'string' OR 'number' must be set as the value of the parameter: will_retry. true found instead`

`FirebaseAnalytics.logEvent` asserts every parameter value is `String` or `num`. The analytics sanitizer in `firebase_analytics_logger.dart` whitelisted `bool` as a passthrough type, so the `will_retry` bool emitted by `playback_error` events tripped the assertion and crashed.

## Fix
Encode bools as `1`/`0` in the sanitizer. Fixing it at the sanitizer (rather than the single `will_retry` call site) covers every current and future call site — any `bool` value is now safe.

## Version
Bumped `2.0.6+20006` → `2.0.7+20007`.

## Testing
- `flutter analyze` clean on changed files.
- `will_retry` is the only bool-valued analytics param in the codebase (confirmed via grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)