### PR TITLE
CI: release + build-release workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,199 @@
+name: Build Release Artifacts
+
+# Triggered when a GitHub Release is published (see release.yml). Builds the
+# signed Android App Bundle and signed iOS IPA, uploads iOS dSYMs to Crashlytics
+# at build time, and stores the AAB / IPA / dSYMs as workflow artifacts.
+#
+# Retention is 1 day for now — these are not yet shipped to the stores.
+
+on:
+  release:
+    types: [published]
+
+env:
+  FLUTTER_VERSION: '3.44.x'
+  JAVA_VERSION: '17'
+
+concurrency:
+  group: build-release-${{ github.event.release.tag_name }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    name: Build signed AAB
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (release tag)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Decode keystore & write key.properties
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KEYSTORE_BASE64:-}" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 secret is not set"; exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
+          # Overwrite the committed key.properties so storeFile points at the
+          # decoded keystore and passwords come from secrets (not the repo).
+          cat > android/key.properties <<EOF
+          keyAlias=${KEY_ALIAS}
+          keyPassword=${KEY_PASSWORD}
+          storeFile=upload-keystore.jks
+          storePassword=${STORE_PASSWORD}
+          EOF
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build App Bundle
+        run: flutter build appbundle --release
+
+      - name: Clean up signing material
+        if: always()
+        run: rm -f android/app/upload-keystore.jks android/key.properties
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dubstepfm-${{ github.event.release.tag_name }}-aab
+          path: build/app/outputs/bundle/release/app-release.aab
+          retention-days: 1
+          if-no-files-found: error
+
+  ios:
+    name: Build signed IPA
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout (release tag)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Import signing certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.IOS_CERT_P12_BASE64 }}
+          p12-password: ${{ secrets.IOS_CERT_PASSWORD }}
+
+      - name: Install provisioning profile
+        env:
+          PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          echo "$PROFILE_BASE64" | base64 --decode \
+            > "$HOME/Library/MobileDevice/Provisioning Profiles/build.mobileprovision"
+
+      - name: Write ExportOptions.plist
+        env:
+          TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+          PROFILE_NAME: ${{ secrets.IOS_PROVISIONING_PROFILE_NAME }}
+        run: |
+          cat > ios/ExportOptions.plist <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store</string>
+            <key>teamID</key>
+            <string>${TEAM_ID}</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>signingCertificate</key>
+            <string>Apple Distribution</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>com.wishnewjam.dubstepfm</key>
+              <string>${PROFILE_NAME}</string>
+            </dict>
+            <key>uploadSymbols</key>
+            <true/>
+            <key>stripSwiftSymbols</key>
+            <true/>
+          </dict>
+          </plist>
+          EOF
+
+      - name: Stub flutterfire CLI (dSYMs uploaded explicitly post-build)
+        # The Runner Xcode project runs "flutterfire upload-crashlytics-symbols"
+        # on every non-Debug build. Wiring the full FlutterFire CLI + generated
+        # firebase_app_id_file.json in CI is fragile, so no-op it here and upload
+        # dSYMs ourselves below with the Crashlytics upload-symbols binary.
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          cat > "$HOME/.local/bin/flutterfire" <<'SH'
+          #!/usr/bin/env bash
+          echo "[CI stub] flutterfire $* — skipping in-build upload"
+          exit 0
+          SH
+          chmod +x "$HOME/.local/bin/flutterfire"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build IPA
+        run: flutter build ipa --release --export-options-plist=ios/ExportOptions.plist
+
+      - name: Upload dSYMs to Crashlytics
+        # Best-effort: uses the GoogleService-Info.plist already in the repo and
+        # the upload-symbols binary that CocoaPods installed with the
+        # FirebaseCrashlytics pod. Runs against the archive's dSYMs.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          UPLOAD_BIN="$(find ios/Pods/FirebaseCrashlytics -name upload-symbols -maxdepth 2 2>/dev/null | head -n1 || true)"
+          DSYMS="build/ios/archive/Runner.xcarchive/dSYMs"
+          if [ -z "$UPLOAD_BIN" ]; then
+            echo "::warning::upload-symbols not found; skipping Crashlytics upload"; exit 0
+          fi
+          if [ ! -d "$DSYMS" ]; then
+            echo "::warning::No dSYMs at $DSYMS; skipping Crashlytics upload"; exit 0
+          fi
+          "$UPLOAD_BIN" -gsp ios/Runner/GoogleService-Info.plist -p ios "$DSYMS"
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dubstepfm-${{ github.event.release.tag_name }}-ipa
+          path: build/ios/ipa/*.ipa
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload dSYMs artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dubstepfm-${{ github.event.release.tag_name }}-dsyms
+          path: build/ios/archive/Runner.xcarchive/dSYMs
+          retention-days: 1
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+# Bumps the version in pubspec.yaml, commits it to the default branch, then
+# tags and publishes a GitHub Release. Publishing the release triggers
+# build-release.yml (which produces the signed AAB + IPA).
+#
+# IMPORTANT: the release must be created with a Personal Access Token, not the
+# default GITHUB_TOKEN. Releases created by GITHUB_TOKEN do NOT trigger other
+# workflows, so build-release.yml would never fire. Add a repo/fine-grained PAT
+# with "contents: write" as the RELEASE_PAT secret.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver part to bump (ignored if "version" is set)'
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+      version:
+        description: 'Explicit version e.g. 2.1.0 (overrides "bump")'
+        type: string
+        default: ''
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Bump version & publish release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Use the PAT so the push + release are attributed to it and the
+          # downstream "on: release" workflow is allowed to trigger.
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Compute next version
+        id: ver
+        run: |
+          set -euo pipefail
+          current="$(grep -E '^version:' pubspec.yaml | sed -E 's/^version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+          echo "Current version: $current"
+
+          if [ -n "${{ inputs.version }}" ]; then
+            next="${{ inputs.version }}"
+          else
+            IFS='.' read -r major minor patch <<< "$current"
+            case "${{ inputs.bump }}" in
+              major) major=$((major + 1)); minor=0; patch=0 ;;
+              minor) minor=$((minor + 1)); patch=0 ;;
+              patch) patch=$((patch + 1)) ;;
+            esac
+            next="${major}.${minor}.${patch}"
+          fi
+
+          if ! [[ "$next" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '$next' (expected MAJOR.MINOR.PATCH)"; exit 1
+          fi
+
+          IFS='.' read -r major minor patch <<< "$next"
+          build=$((major * 10000 + minor * 100 + patch))
+
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+          echo "build=$build" >> "$GITHUB_OUTPUT"
+          echo "tag=v$next" >> "$GITHUB_OUTPUT"
+          echo "Next version: $next+$build (tag v$next)"
+
+      - name: Fail if tag already exists
+        run: |
+          if git rev-parse "refs/tags/${{ steps.ver.outputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ steps.ver.outputs.tag }} already exists"; exit 1
+          fi
+
+      - name: Update pubspec.yaml
+        run: |
+          sed -i -E "s/^version:.*/version: ${{ steps.ver.outputs.next }}+${{ steps.ver.outputs.build }}/" pubspec.yaml
+          grep -E '^version:' pubspec.yaml
+
+      - name: Commit version bump
+        id: commit
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add pubspec.yaml
+          git commit -m "Release ${{ steps.ver.outputs.next }}"
+          git push origin HEAD:${{ github.ref_name }}
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          gh release create "${{ steps.ver.outputs.tag }}" \
+            --target "${{ steps.commit.outputs.sha }}" \
+            --title "${{ steps.ver.outputs.next }}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,11 @@ name: Release
 # tags and publishes a GitHub Release. Publishing the release triggers
 # build-release.yml (which produces the signed AAB + IPA).
 #
-# IMPORTANT: the release must be created with a Personal Access Token, not the
-# default GITHUB_TOKEN. Releases created by GITHUB_TOKEN do NOT trigger other
-# workflows, so build-release.yml would never fire. Add a repo/fine-grained PAT
-# with "contents: write" as the RELEASE_PAT secret.
+# IMPORTANT: the push + release are made with a GitHub App installation token,
+# not the default GITHUB_TOKEN. Releases created by GITHUB_TOKEN do NOT trigger
+# other workflows, so build-release.yml would never fire. The App needs
+# "Contents: read and write" and must be installed on this repo. Provide its
+# credentials as the APP_ID and APP_PRIVATE_KEY secrets.
 
 on:
   workflow_dispatch:
@@ -34,12 +35,19 @@ jobs:
       contents: write
 
     steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Use the PAT so the push + release are attributed to it and the
-          # downstream "on: release" workflow is allowed to trigger.
-          token: ${{ secrets.RELEASE_PAT }}
+          # Use the App token so the push + release are attributed to the App
+          # and the downstream "on: release" workflow is allowed to trigger.
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Compute next version
@@ -96,7 +104,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release create "${{ steps.ver.outputs.tag }}" \
             --target "${{ steps.commit.outputs.sha }}" \


### PR DESCRIPTION
Adds two workflows.

## `release.yml` — manual version bump + GitHub Release
`workflow_dispatch` with inputs:
- `bump`: `patch` / `minor` / `major` (default `patch`)
- `version`: explicit `MAJOR.MINOR.PATCH` override

Computes the new version + build number (`major*10000 + minor*100 + patch`, e.g. `2.0.7` → `20007`), commits the `pubspec.yaml` bump to the default branch, tags `vX.Y.Z`, and publishes a GitHub Release.

## `build-release.yml` — on `release: published`
- **Android:** decodes keystore from secrets, writes a CI `key.properties`, builds the signed `.aab`.
- **iOS:** imports cert + provisioning profile, writes `ExportOptions.plist`, builds the signed `.ipa`, and uploads dSYMs to Crashlytics at build time (via the FirebaseCrashlytics `upload-symbols` binary + the repo `GoogleService-Info.plist`).
- Stores **AAB / IPA / dSYMs** as artifacts with **1-day retention**.

## Required secrets
**`release.yml`**
- `RELEASE_PAT` — PAT with `contents: write`. Required because a Release created by the default `GITHUB_TOKEN` does **not** trigger `on: release` workflows, so `build-release.yml` would never fire.

**`build-release.yml` — Android**
- `ANDROID_KEYSTORE_BASE64` — `base64 -i dubstepfm.jks`
- `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`, `ANDROID_STORE_PASSWORD`

**`build-release.yml` — iOS**
- `IOS_CERT_P12_BASE64`, `IOS_CERT_PASSWORD` — Apple Distribution cert (.p12)
- `IOS_PROVISIONING_PROFILE_BASE64`, `IOS_PROVISIONING_PROFILE_NAME` — App Store profile for `com.wishnewjam.dubstepfm`
- `IOS_TEAM_ID` — `S927UVDYKH`

## Notes / follow-ups
- iOS archive signing assumes **manual** signing via the installed profile; the Runner target is currently `CODE_SIGN_STYLE = Automatic`. If the archive step rejects manual signing, switch the Release config to Manual (or I can add a CI patch step).
- Crashlytics dSYM upload is best-effort (`continue-on-error`) so a Firebase hiccup never fails the build; dSYMs are also kept as an artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)